### PR TITLE
Feat/defaults update

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -17,7 +17,7 @@ prometheus_node_exporter_loglevel: '{{ prometheus_loglevel }}'
 prometheus_node_exporter_listen: '{{ prometheus_node_exporter_listen_ip }}:{{ prometheus_node_exporter_listen_port }}'
 prometheus_node_exporter_listen_port: '9100'
 prometheus_node_exporter_listen_ip: ''
-prometheus_node_exporter_version: '0.17.0'
+prometheus_node_exporter_version: '1.3.1'
 prometheus_node_exporter_validate_certs: true
 
 enable_ufw: false

--- a/templates/node_exporter.defaults.j2
+++ b/templates/node_exporter.defaults.j2
@@ -3,4 +3,4 @@
 START=yes
 
 #
-STARTUP_ARGS=' --web.listen-address {{ prometheus_node_exporter_listen }} --collector.ntp.server=127.0.0.1 --collector.ntp --collector.systemd --log.level={{ prometheus_node_exporter_loglevel }} --collector.filesystem.ignored-fs-types=\"^(sys|proc|auto|tmp|ns)fs|overlay$\" '
+STARTUP_ARGS=' --web.listen-address {{ prometheus_node_exporter_listen }} --collector.ntp.server=127.0.0.1 --collector.ntp --collector.systemd --log.level={{ prometheus_node_exporter_loglevel }} --collector.filesystem.fs-types-exclude=\"^(sys|proc|auto|tmp|ns)fs|overlay$\" '

--- a/templates/node_exporter.defaults.j2
+++ b/templates/node_exporter.defaults.j2
@@ -3,4 +3,8 @@
 START=yes
 
 #
-STARTUP_ARGS=' --web.listen-address {{ prometheus_node_exporter_listen }} --collector.ntp.server=127.0.0.1 --collector.ntp --collector.systemd --log.level={{ prometheus_node_exporter_loglevel }} --collector.filesystem.fs-types-exclude=\"^(sys|proc|auto|tmp|ns)fs|overlay$\" '
+STARTUP_ARGS=" --web.listen-address {{ prometheus_node_exporter_listen }}
+        --collector.ntp.server=127.0.0.1 --collector.ntp --collector.systemd --log.level=info
+        --collector.filesystem.fs-types-exclude='^(sys|proc|auto|tmp|ns|squash)fs|overlay$'
+        --collector.filesystem.mount-points-exclude='^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)'
+        "


### PR DESCRIPTION
- exclude 'squashfs' fstype from collected metrics
- in addition to `fs-types-exclude`, use `mount-points-exclude`
- use current node_exporter version '1.3.1'
- do not use deprecated options
 